### PR TITLE
[Fix] 디렉토링 목록이 제대로 나오지 않는 오류 수정

### DIFF
--- a/webserve/RequestHandler/ServerHandler/ServerHandler.cpp
+++ b/webserve/RequestHandler/ServerHandler/ServerHandler.cpp
@@ -317,6 +317,8 @@ std::string ServerHandler::findPath(std::string request_target)
     }
     else if (access(directory.c_str(), F_OK) != -1)
     {
+        if (_config.getAutoindex())
+            return (directory);
         std::vector<std::string>::iterator it = index_path.begin();
         for (; it != index_path.end(); it++)
         {


### PR DESCRIPTION
1. findPath 함수 내 디렉토리가 존재 할 경우 autoindex 설정 검사 후 on 이면 디렉토리 경로 반환

resolved #89