### PR TITLE
[Fix] 디렉토링 목록 하이퍼링크 오류 수정

### DIFF
--- a/webserve/RequestHandler/ServerHandler/ServerHandler.cpp
+++ b/webserve/RequestHandler/ServerHandler/ServerHandler.cpp
@@ -294,7 +294,7 @@ std::string ServerHandler::findPath(std::string request_target)
     // 요청 url
     std::string change;
     std::string clean_request_target = cleanUrl(request_target, false);
-    if (_config.getUrl().empty())
+    if (_config.getUrl().empty() || _config.getUrl() == "/")
         change = clean_request_target;
     else
         change = clean_request_target.substr(_config.getUrl().length());


### PR DESCRIPTION
1. cleanUrl 조건중 /가 오면 그냥 requestTarget 붙이도록 수정

resolved #91