### PR TITLE
[Fix] 파일업로드 오류 발생

### DIFF
--- a/var/conf/webserv.conf
+++ b/var/conf/webserv.conf
@@ -8,6 +8,6 @@ server
     upload_path var/upload/test;
 	index index.html;
 	error_page  400 404 405 413 /error-page/40x.html;
-	cgi_config .bla:./cgi_tester .php:/usr/bin/php .py:/opt/homebrew/bin/python3 .pl:/usr/bin/perl .sh:/bin/sh;
+	cgi_config .bla:./cgi_tester .php:/usr/bin/php .py:/usr/bin/python .pl:/usr/bin/perl .sh:/bin/sh;
     allow_method GET HEAD POST DELETE PUT;
 }


### PR DESCRIPTION
1. config 파일 내의 cgi_config의 path가 잘못되어 있던 것이 원인

resolved #105